### PR TITLE
Fix bool map JSON generation

### DIFF
--- a/compiler/cpp/src/generate/t_cocoa_generator.cc
+++ b/compiler/cpp/src/generate/t_cocoa_generator.cc
@@ -1750,7 +1750,7 @@ void t_cocoa_generator::generate_cocoa_struct_to_json_method(
       }
     } else if (base == t_base_type::TYPE_BOOL) {
       string accessor;
-      if (is_container_element) {
+      if (is_container_element && !is_map_element) {
         accessor = "[" + field_name + " boolValue]";
       } else {
         accessor = field_name;


### PR DESCRIPTION
Boolean map values are output with incorrect format, causing crash at
runtime due to casting error. Use primitive format for bool values
inside maps. Basically the same fix as 9dbb868 which was made previously
for int values.