### PR TITLE
Update Swift generation to use to send telemetry

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -304,7 +304,7 @@ public enum TelemetryValue {
   case bool(Bool)
   case dictionary(TelemetryDictionary)
 
-  init(_ value: Any) {
+  fileprivate init(_ value: Any) {
     if let string = value as? String {
       return .string(string)
     }
@@ -444,7 +444,7 @@ void t_swift_generator::generate_enum(t_enum* tenum) {
   }
 
   if (telemetry_object_) {
-    f_impl_ << indent() << "public func telemetryValue() -> TelemetryValue";
+    f_impl_ << indent() << "fileprivate func telemetryValue() -> TelemetryValue";
     block_open(f_impl_);
     if (boost::algorithm::ends_with(tenum->get_name(), "AsInt")) {
       f_impl_ << indent() << "return .string(\"\\(rawValue)\")" << endl;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -68,7 +68,10 @@ public:
         promise_kit_ = true;
       } else if( iter->first.compare("debug_descriptions") == 0) {
         debug_descriptions_ = true;
-      } else {
+      } else if( iter->first.compare("exclude_thrift_types") == 0) {
+	exclude_thrift_types_ = true;
+      }
+      else {
         throw "unknown option swift:" + iter->first;
       }
     }
@@ -235,6 +238,7 @@ private:
   bool async_clients_;
   bool promise_kit_;
   bool debug_descriptions_;
+  bool exclude_thrift_types_;
 
   set<string> swift_reserved_words_;
 };
@@ -299,7 +303,9 @@ string t_swift_generator::swift_imports() {
 string t_swift_generator::swift_thrift_imports() {
 
   vector<string> includes_list;
-  includes_list.push_back("Thrift");
+  if (!exclude_thrift_types_) {
+    includes_list.push_back("Thrift");
+  }
 
   if (promise_kit_) {
     includes_list.push_back("PromiseKit");
@@ -362,24 +368,29 @@ void t_swift_generator::generate_enum(t_enum* tenum) {
   block_close(f_decl_);
   f_decl_ << endl;
 
-  f_impl_ << indent() << "extension " << tenum->get_name() << " : TEnum";
+  f_impl_ << indent() << "extension " << tenum->get_name();
+  if (!exclude_thrift_types_) {
+    f_impl_ << " : TEnum";
+  }
   block_open(f_impl_);
 
   f_impl_ << endl;
 
-  f_impl_ << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
-  block_open(f_impl_);
-  f_impl_ << indent() << "var raw = Int32()" << endl
-          << indent() << "try proto.readI32(&raw)" << endl
-          << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
-  block_close(f_impl_);
-  f_impl_ << endl;
+  if (!exclude_thrift_types_) {
+    f_impl_ << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
+    block_open(f_impl_);
+    f_impl_ << indent() << "var raw = Int32()" << endl
+            << indent() << "try proto.readI32(&raw)" << endl
+            << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
+    block_close(f_impl_);
+    f_impl_ << endl;
 
-  f_impl_ << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
-  block_open(f_impl_);
-  f_impl_ << indent() << "try proto.writeI32(value.rawValue)" << endl;
-  block_close(f_impl_);
-  f_impl_ << endl;
+    f_impl_ << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
+    block_open(f_impl_);
+    f_impl_ << indent() << "try proto.writeI32(value.rawValue)" << endl;
+    block_close(f_impl_);
+    f_impl_ << endl;
+  }
 
   block_close(f_impl_);
   f_impl_ << endl;
@@ -682,19 +693,24 @@ void t_swift_generator::generate_swift_struct_thrift_extension(ofstream& out,
                                                                bool is_result,
                                                                bool is_private) {
 
-  indent(out) << "extension " << tstruct->get_name() << " : TStruct";
+  indent(out) << "extension " << tstruct->get_name();
+  if (!exclude_thrift_types_) {
+    out << " : TStruct";
+  }
 
   block_open(out);
 
   out << endl;
 
-  generate_swift_struct_reader(out, tstruct, is_private);
+  if (!exclude_thrift_types_) {
+    generate_swift_struct_reader(out, tstruct, is_private);
 
-  if (is_result) {
-    generate_swift_struct_result_writer(out, tstruct);
-  }
-  else {
-    generate_swift_struct_writer(out, tstruct, is_private);
+    if (is_result) {
+      generate_swift_struct_result_writer(out, tstruct);
+    }
+    else {
+      generate_swift_struct_writer(out, tstruct, is_private);
+    }
   }
 
   block_close(out);
@@ -1798,7 +1814,12 @@ string t_swift_generator::type_name(t_type* ttype, bool is_optional, bool is_for
     result = base_type_name((t_base_type*)ttype);
   } else if (ttype->is_map()) {
     t_map *map = (t_map *)ttype;
-    result = "TMap<" + type_name(map->get_key_type()) + ", " + type_name(map->get_val_type()) + ">";
+    if (exclude_thrift_types_) {
+      result = "[" + type_name(map->get_key_type()) + ": " + type_name(map->get_val_type()) + "]";
+    }
+    else {
+      result = "TMap<" + type_name(map->get_key_type()) + ", " + type_name(map->get_val_type()) + ">";
+    }
   } else if (ttype->is_set()) {
     t_set *set = (t_set *)ttype;
     result = "TSet<" + type_name(set->get_elem_type()) + ">";
@@ -2093,7 +2114,7 @@ string t_swift_generator::argument_list(t_struct* tstruct, string protocol_name,
   const vector<t_field*>& fields = tstruct->get_members();
   vector<t_field*>::const_iterator f_iter;
 
-  if (include_protocol) {
+  if (include_protocol && !exclude_thrift_types_) {
     result += protocol_name + ": TProtocol";
     if (!fields.empty()) {
       result += ", ";

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -299,7 +299,7 @@ public protocol TelemetryObject {
   func telemetryDictionary() -> TelemetryDictionary
 }
 
-public enum TelemetryValue {
+public enum TelemetryValue: Equatable {
   case string(String)
   case bool(Bool)
   case dictionary(TelemetryDictionary)

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -306,17 +306,17 @@ public enum TelemetryValue {
 
   fileprivate init(_ value: Any) {
     if let string = value as? String {
-      return .string(string)
+      self = .string(string)
     }
     else if let bool = value as? Bool {
-      return .bool(bool)
+      self = .bool(bool)
     }
     else if let telemetryObject = value as? TelemetryObject {
-      return .dictionary(value.telemetryDictionary())
+      self = .dictionary(telemetryObject.telemetryDictionary())
     }
     else {
       // Convert other types to string
-      return .string("\(value)")
+      self = .string("\(value)")
     }
   }
 }
@@ -605,8 +605,8 @@ void t_swift_generator::generate_swift_struct_init(ofstream& out,
 
   for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
     if (all || (*m_iter)->get_req() == t_field::T_REQUIRED || (*m_iter)->get_req() == t_field::T_OPT_IN_REQ_OUT) {
-      out << indent() << "self." << maybe_escape_identifier(struct_property_name(*m_iter)) << " = "
-          << maybe_escape_identifier(struct_property_name(*m_iter)) << endl;
+      out << indent() << "self." << struct_property_name(*m_iter) << " = "
+          << struct_property_name(*m_iter) << endl;
     }
   }
 
@@ -634,7 +634,7 @@ void t_swift_generator::generate_swift_struct_hashable_extension(ofstream& out,
 
   out << endl;
 
-  indent(out) << visibility << " var hashValue : Int";
+  indent(out) << visibility << " func hash(into hasher: inout Hasher)";
 
   block_open(out);
 
@@ -642,22 +642,9 @@ void t_swift_generator::generate_swift_struct_hashable_extension(ofstream& out,
   const vector<t_field*>& members = tstruct->get_members();
   vector<t_field*>::const_iterator m_iter;
 
-  if (!members.empty()) {
-    indent(out) << "let prime = 31" << endl;
-    indent(out) << "var result = 1" << endl;
-
-    for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
-      t_field* tfield = *m_iter;
-      string accessor = field_is_optional(tfield) ? "?." : ".";
-      string defaultor = field_is_optional(tfield) ? " ?? 0" : "";
-      indent(out) << "result = prime &* result &+ (" << maybe_escape_identifier(struct_property_name(tfield)) << accessor
-                  <<  "hashValue" << defaultor << ")" << endl;
-    }
-
-    indent(out) << "return result" << endl;
-  }
-  else {
-    indent(out) << "return 31" << endl;
+  for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
+    t_field* tfield = *m_iter;
+    indent(out) << "hasher.combine(" << struct_property_name(tfield) << ")" << endl;
   }
 
   block_close(out);
@@ -699,8 +686,8 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
 
     for (m_iter = members.begin(); m_iter != members.end();) {
       t_field* tfield = *m_iter;
-      indent(out) << "(lhs." << maybe_escape_identifier(struct_property_name(tfield))
-                  << " == rhs." << maybe_escape_identifier(struct_property_name(tfield)) << ")";
+      indent(out) << "(lhs." << struct_property_name(tfield)
+                  << " == rhs." << struct_property_name(tfield) << ")";
       if (++m_iter != members.end()) {
         out << " &&";
       }
@@ -858,7 +845,7 @@ void t_swift_generator::generate_swift_struct_reader(ofstream& out,
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     bool optional = field_is_optional(*f_iter);
-    indent(out) << "var " << maybe_escape_identifier(struct_property_name(*f_iter)) << " : "
+    indent(out) << "var " << struct_property_name(*f_iter) << " : "
                 << type_name((*f_iter)->get_type(), optional, !optional) << endl;
   }
 
@@ -974,8 +961,8 @@ void t_swift_generator::generate_swift_struct_writer(ofstream& out,
 
     bool optional = field_is_optional(tfield);
     if (optional) {
-      indent(out) << "if let " << maybe_escape_identifier(struct_property_name(tfield))
-                  << " = __value." << maybe_escape_identifier(struct_property_name(tfield));
+      indent(out) << "if let " << struct_property_name(tfield)
+                  << " = __value." << struct_property_name(tfield);
       block_open(out);
     }
 
@@ -1077,7 +1064,7 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
     indent(out) << "desc += \"" << struct_property_name(*f_iter)
-                << "=\\(self." << maybe_escape_identifier(struct_property_name(*f_iter)) << ")";
+                << "=\\(self." << struct_property_name(*f_iter) << ")";
     if (++f_iter != fields.end()) {
       out << ", ";
     }
@@ -2139,7 +2126,7 @@ string t_swift_generator::declare_property(t_field* tfield, bool is_private) {
 
   ostringstream render;
 
-  render << visibility << " var " << maybe_escape_identifier(struct_property_name(tfield));
+  render << visibility << " var " << struct_property_name(tfield);
 
   if (tfield->get_value() != NULL) {
     t_type* type = tfield->get_type();
@@ -2288,11 +2275,11 @@ void t_swift_generator::populate_reserved_words() {
 }
 
 string t_swift_generator::struct_property_name(t_field* tfield) {
-  return camel_case_from_underscore(tfield->get_name());
+  return maybe_escape_identifier(camel_case_from_underscore(tfield->get_name()));
 }
 
 string t_swift_generator::enum_value_name(t_enum_value* tenumvalue) {
-  return camel_case_from_underscore(tenumvalue->get_name());
+  return maybe_escape_identifier(camel_case_from_underscore(tenumvalue->get_name()));
 }
  
 string t_swift_generator::camel_case_from_underscore(string underscore_name) {

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -183,7 +183,6 @@ public:
   string base_type_name(t_base_type* tbase);
   string declare_property(t_field* tfield, bool is_private);
   string function_signature(t_function* tfunction);
-  string render_const_value(t_type* type, t_const_value* value);
   string async_function_signature(t_function* tfunction);
   string promise_function_signature(t_function* tfunction);
   string function_name(t_function* tfunction);
@@ -2145,7 +2144,8 @@ string t_swift_generator::declare_property(t_field* tfield, bool is_private) {
 
   if (tfield->get_value() != NULL) {
     t_type* type = tfield->get_type();
-    render << " = " << render_const_value(type, tfield->get_value());
+    render << " = ";
+    render_const_value(render, type, tfield->get_value());
   }
   else {
     if (field_is_optional(tfield)) {
@@ -2154,44 +2154,6 @@ string t_swift_generator::declare_property(t_field* tfield, bool is_private) {
     else {
       render << " = " << type_name(tfield->get_type(), false) << "()";
     }
-  }
-
-  return render.str();
-}
-
-string t_swift_generator::render_const_value(t_type* type, t_const_value* value) {
-  type = get_true_type(type);
-  std::ostringstream render;
-
-  if (type->is_base_type()) {
-    t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
-    switch (tbase) {
-    case t_base_type::TYPE_STRING:
-      render << "\"" + get_escaped_string(value) + "\"";
-      break;
-    case t_base_type::TYPE_BOOL:
-      render << ((value->get_integer() > 0) ? "true" : "false");
-      break;
-    case t_base_type::TYPE_I8:
-    case t_base_type::TYPE_I16:
-    case t_base_type::TYPE_I32:
-    case t_base_type::TYPE_I64:
-      render << value->get_integer();
-      break;
-    case t_base_type::TYPE_DOUBLE:
-      if (value->get_type() == t_const_value::CV_INTEGER) {
-        render << value->get_integer();
-      } else {
-        render << value->get_double();
-      }
-      break;
-    default:
-      throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
-    }
-  } else if (type->is_enum()) {
-    render << value->get_identifier();
-  } else {
-    throw "compiler error: unsupported default type " + type->get_name();
   }
 
   return render.str();

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -700,7 +700,7 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
     for (m_iter = members.begin(); m_iter != members.end();) {
       t_field* tfield = *m_iter;
       indent(out) << "(lhs." << maybe_escape_identifier(struct_property_name(tfield))
-                  << " ?== rhs." << maybe_escape_identifier(struct_property_name(tfield)) << ")";
+                  << " == rhs." << maybe_escape_identifier(struct_property_name(tfield)) << ")";
       if (++m_iter != members.end()) {
         out << " &&";
       }

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -2025,9 +2025,8 @@ void t_swift_generator::render_const_value(ostream& out,
       throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
     }
   } else if (type->is_enum()) {
-    out << value->get_identifier();
+    out << type->get_name() << "." << camel_case_from_underscore(value->get_identifier_name());
   } else if (type->is_struct() || type->is_xception()) {
-
     out << type_name(type) << "(";
 
     const vector<t_field*>& fields = ((t_struct*)type)->get_members();

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -193,6 +193,7 @@ public:
   void populate_reserved_words();
   string enum_value_name(t_enum_value* tenumvalue);
   string struct_property_name(t_field* field);
+  string camel_case_from_underscore(string underscore_name);
 
 private:
 
@@ -594,7 +595,7 @@ void t_swift_generator::generate_swift_struct_init(ofstream& out,
       else {
         out << ", ";
       }
-      out << (*m_iter)->get_name() << ": "
+      out << struct_property_name(*m_iter) << ": "
           << maybe_escape_identifier(type_name((*m_iter)->get_type(), field_is_optional(*m_iter)));
     }
     ++m_iter;
@@ -605,8 +606,8 @@ void t_swift_generator::generate_swift_struct_init(ofstream& out,
 
   for (m_iter = members.begin(); m_iter != members.end(); ++m_iter) {
     if (all || (*m_iter)->get_req() == t_field::T_REQUIRED || (*m_iter)->get_req() == t_field::T_OPT_IN_REQ_OUT) {
-      out << indent() << "self." << maybe_escape_identifier((*m_iter)->get_name()) << " = "
-          << maybe_escape_identifier((*m_iter)->get_name()) << endl;
+      out << indent() << "self." << maybe_escape_identifier(struct_property_name(*m_iter)) << " = "
+          << maybe_escape_identifier(struct_property_name(*m_iter)) << endl;
     }
   }
 
@@ -699,8 +700,8 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
 
     for (m_iter = members.begin(); m_iter != members.end();) {
       t_field* tfield = *m_iter;
-      indent(out) << "(lhs." << maybe_escape_identifier(tfield->get_name())
-                  << " ?== rhs." << maybe_escape_identifier(tfield->get_name()) << ")";
+      indent(out) << "(lhs." << maybe_escape_identifier(struct_property_name(tfield))
+                  << " ?== rhs." << maybe_escape_identifier(struct_property_name(tfield)) << ")";
       if (++m_iter != members.end()) {
         out << " &&";
       }
@@ -1076,7 +1077,7 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
   vector<t_field*>::const_iterator f_iter;
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
-    indent(out) << "desc += \"" << (*f_iter)->get_name()
+    indent(out) << "desc += \"" << struct_property_name(*f_iter)
                 << "=\\(self." << maybe_escape_identifier(struct_property_name(*f_iter)) << ")";
     if (++f_iter != fields.end()) {
       out << ", ";
@@ -2326,13 +2327,33 @@ void t_swift_generator::populate_reserved_words() {
 }
 
 string t_swift_generator::struct_property_name(t_field* tfield) {
-  // TODO: Camel-case
-  return tfield->get_name();
+  return camel_case_from_underscore(tfield->get_name());
 }
 
 string t_swift_generator::enum_value_name(t_enum_value* tenumvalue) {
-  // TODO: Camel-case
-  return tenumvalue->get_name();
+  return camel_case_from_underscore(tenumvalue->get_name());
+}
+ 
+string t_swift_generator::camel_case_from_underscore(string underscore_name) {
+  // Convert to camel case
+  std::string cap_value_name = underscore_name;
+  cap_value_name[0] = tolower(underscore_name[0]);
+
+  // Underscores separate words
+  bool cap_next = false;
+  for (string::iterator iter = cap_value_name.begin(); iter < cap_value_name.end(); iter++) {
+    if (cap_next) {
+      *iter = toupper(*iter);
+      cap_next = false;
+    }
+    else if (*iter == '_') {
+      cap_next = true;
+    }
+  }
+
+  boost::replace_all(cap_value_name, "_", "");
+
+  return cap_value_name;
 }
 
 string t_swift_generator::maybe_escape_identifier(const string& identifier) {

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -1064,7 +1064,7 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
     indent(out) << "desc += \"" << struct_property_name(*f_iter)
-                << "=\\(self." << struct_property_name(*f_iter) << ")";
+                << "=\\(String(describing: self." << struct_property_name(*f_iter) << "))";
     if (++f_iter != fields.end()) {
       out << ", ";
     }

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -71,9 +71,9 @@ public:
       } else if( iter->first.compare("debug_descriptions") == 0) {
         debug_descriptions_ = true;
       } else if( iter->first.compare("exclude_thrift_types") == 0) {
-	exclude_thrift_types_ = true;
+        exclude_thrift_types_ = true;
       } else if( iter->first.compare("telemetry_object") == 0) {
-	telemetry_object_ = true;
+        telemetry_object_ = true;
       }
       else {
         throw "unknown option swift:" + iter->first;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -28,6 +28,8 @@
 #include <sstream>
 #include "thrift/platform.h"
 #include "thrift/generate/t_oop_generator.h"
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 using std::map;
 using std::ostream;
@@ -70,6 +72,8 @@ public:
         debug_descriptions_ = true;
       } else if( iter->first.compare("exclude_thrift_types") == 0) {
 	exclude_thrift_types_ = true;
+      } else if( iter->first.compare("telemetry_object") == 0) {
+	telemetry_object_ = true;
       }
       else {
         throw "unknown option swift:" + iter->first;
@@ -171,6 +175,7 @@ public:
    * Helper rendering functions
    */
 
+  string telemetry_object_protocols();
   string swift_imports();
   string swift_thrift_imports();
   string type_name(t_type* ttype, bool is_optional=false, bool is_forced=false);
@@ -184,6 +189,7 @@ public:
   string type_to_enum(t_type* ttype, bool qualified=false);
   string maybe_escape_identifier(const string& identifier);
   void populate_reserved_words();
+  string enum_value_name(t_enum_value* tenumvalue);
 
 private:
 
@@ -239,6 +245,7 @@ private:
   bool promise_kit_;
   bool debug_descriptions_;
   bool exclude_thrift_types_;
+  bool telemetry_object_;
 
   set<string> swift_reserved_words_;
 };
@@ -271,6 +278,29 @@ void t_swift_generator::init_generator() {
 
   f_impl_ << swift_imports() << swift_thrift_imports() << endl;
 
+  if (telemetry_object_) {
+    f_impl_ << telemetry_object_protocols() << endl << endl;
+  }
+}
+
+/**
+ * Prints protocols necessary for telemetry objects
+ *
+ * @return Protocols for telemetry objects
+ */
+string t_swift_generator::telemetry_object_protocols() {
+  return R"objc(
+public typealias TelemetryDictionary = [String: TelemetryValue]
+
+public protocol TelemetryObject {
+  func telemetryValue() -> TelemetryDictionary
+}
+
+public enum TelemetryValue {
+  case string(String)
+  case bool(Bool)
+  case object(TelemetryDictionary)
+})objc";
 }
 
 /**
@@ -358,7 +388,7 @@ void t_swift_generator::generate_enum(t_enum* tenum) {
   vector<t_enum_value*>::iterator c_iter;
 
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-    f_decl_ << indent() << "case " << (*c_iter)->get_name()
+    f_decl_ << indent() << "case " << enum_value_name(*c_iter)
             << " = " << (*c_iter)->get_value() << endl;
   }
 
@@ -390,6 +420,22 @@ void t_swift_generator::generate_enum(t_enum* tenum) {
     f_impl_ << indent() << "try proto.writeI32(value.rawValue)" << endl;
     block_close(f_impl_);
     f_impl_ << endl;
+  }
+
+  if (telemetry_object_) {
+    f_impl_ << indent() << "public func telemetryValue() -> TelemetryValue";
+    block_open(f_impl_);
+    if (boost::algorithm::ends_with(tenum->get_name(), "AsInt")) {
+      f_impl_ << indent() << "return .string(\"\\(rawValue)\")" << endl;
+    }
+    else {
+      f_impl_ << indent() << "switch self {" << endl;
+      for (const auto& value : tenum->get_constants()) {
+        f_impl_ << indent() << "case ." << enum_value_name(value) << ": return .string(\"" << value->get_name() << "\")" << endl;
+      }
+      f_impl_ << indent() << "}" << endl;
+    }
+    block_close(f_impl_);
   }
 
   block_close(f_impl_);
@@ -2167,6 +2213,11 @@ void t_swift_generator::populate_reserved_words() {
   swift_reserved_words_.insert("true");
   swift_reserved_words_.insert("typealias");
   swift_reserved_words_.insert("where");
+}
+
+string t_swift_generator::enum_value_name(t_enum_value* tenumvalue) {
+  // TODO: Camel-case
+  return tenumvalue->get_name();
 }
 
 string t_swift_generator::maybe_escape_identifier(const string& identifier) {

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -183,6 +183,7 @@ public:
   string base_type_name(t_base_type* tbase);
   string declare_property(t_field* tfield, bool is_private);
   string function_signature(t_function* tfunction);
+  string render_const_value(t_type* type, t_const_value* value);
   string async_function_signature(t_function* tfunction);
   string promise_function_signature(t_function* tfunction);
   string function_name(t_function* tfunction);
@@ -2141,11 +2142,55 @@ string t_swift_generator::declare_property(t_field* tfield, bool is_private) {
 
   render << visibility << " var " << maybe_escape_identifier(struct_property_name(tfield));
 
-  if (field_is_optional(tfield)) {
-    render << " : " << type_name(tfield->get_type(), true);
+  if (tfield->get_value() != NULL) {
+    t_type* type = tfield->get_type();
+    render << " = " << render_const_value(type, tfield->get_value());
   }
   else {
-    render << " = " << type_name(tfield->get_type(), false) << "()";
+    if (field_is_optional(tfield)) {
+      render << " : " << type_name(tfield->get_type(), true);
+    }
+    else {
+      render << " = " << type_name(tfield->get_type(), false) << "()";
+    }
+  }
+
+  return render.str();
+}
+
+string t_swift_generator::render_const_value(t_type* type, t_const_value* value) {
+  type = get_true_type(type);
+  std::ostringstream render;
+
+  if (type->is_base_type()) {
+    t_base_type::t_base tbase = ((t_base_type*)type)->get_base();
+    switch (tbase) {
+    case t_base_type::TYPE_STRING:
+      render << "\"" + get_escaped_string(value) + "\"";
+      break;
+    case t_base_type::TYPE_BOOL:
+      render << ((value->get_integer() > 0) ? "true" : "false");
+      break;
+    case t_base_type::TYPE_I8:
+    case t_base_type::TYPE_I16:
+    case t_base_type::TYPE_I32:
+    case t_base_type::TYPE_I64:
+      render << value->get_integer();
+      break;
+    case t_base_type::TYPE_DOUBLE:
+      if (value->get_type() == t_const_value::CV_INTEGER) {
+        render << value->get_integer();
+      } else {
+        render << value->get_double();
+      }
+      break;
+    default:
+      throw "compiler error: no const of base type " + t_base_type::t_base_name(tbase);
+    }
+  } else if (type->is_enum()) {
+    render << value->get_identifier();
+  } else {
+    throw "compiler error: unsupported default type " + type->get_name();
   }
 
   return render.str();

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -130,6 +130,7 @@ public:
   void generate_swift_struct_equatable_extension(ofstream& out,
                                                  t_struct* tstruct,
                                                  bool is_private);
+  void generate_swift_struct_telemetry_object_extension(ofstream& out, t_struct* tstruct);
   void generate_swift_struct_thrift_extension(ofstream& out,
                                               t_struct* tstruct,
                                               bool is_result,
@@ -190,6 +191,7 @@ public:
   string maybe_escape_identifier(const string& identifier);
   void populate_reserved_words();
   string enum_value_name(t_enum_value* tenumvalue);
+  string struct_property_name(t_field* field);
 
 private:
 
@@ -293,14 +295,32 @@ string t_swift_generator::telemetry_object_protocols() {
 public typealias TelemetryDictionary = [String: TelemetryValue]
 
 public protocol TelemetryObject {
-  func telemetryValue() -> TelemetryDictionary
+  func telemetryDictionary() -> TelemetryDictionary
 }
 
 public enum TelemetryValue {
   case string(String)
   case bool(Bool)
-  case object(TelemetryDictionary)
-})objc";
+  case dictionary(TelemetryDictionary)
+
+  init(_ value: Any) {
+    if let string = value as? String {
+      return .string(string)
+    }
+    else if let bool = value as? Bool {
+      return .bool(bool)
+    }
+    else if let telemetryObject = value as? TelemetryObject {
+      return .dictionary(value.telemetryDictionary())
+    }
+    else {
+      // Convert other types to string
+      return .string("\(value)")
+    }
+  }
+}
+
+)objc";
 }
 
 /**
@@ -629,7 +649,7 @@ void t_swift_generator::generate_swift_struct_hashable_extension(ofstream& out,
       t_field* tfield = *m_iter;
       string accessor = field_is_optional(tfield) ? "?." : ".";
       string defaultor = field_is_optional(tfield) ? " ?? 0" : "";
-      indent(out) << "result = prime &* result &+ (" << maybe_escape_identifier(tfield->get_name()) << accessor
+      indent(out) << "result = prime &* result &+ (" << maybe_escape_identifier(struct_property_name(tfield)) << accessor
                   <<  "hashValue" << defaultor << ")" << endl;
     }
 
@@ -720,9 +740,60 @@ void t_swift_generator::generate_swift_struct_implementation(ofstream& out,
   }
 
   generate_swift_struct_hashable_extension(out, tstruct, is_private);
-  generate_swift_struct_thrift_extension(out, tstruct, is_result, is_private);
-
+  if (!exclude_thrift_types_) {
+    generate_swift_struct_thrift_extension(out, tstruct, is_result, is_private);
+  }
+  if (telemetry_object_) {
+    generate_swift_struct_telemetry_object_extension(out, tstruct);
+  }
   out << endl << endl;
+}
+
+/**
+ * Generate the TelemetryObject protocol implementation
+ *
+ * @param tstruct The structure definition
+ */
+void t_swift_generator::generate_swift_struct_telemetry_object_extension(ofstream& out, t_struct* tstruct) {
+  indent(out) << "extension " << tstruct->get_name() << " : TelemetryObject";
+  block_open(out);
+
+  out << endl;
+
+  out << indent() << "public func telemetryDictionary() -> TelemetryDictionary";
+  block_open(out);
+ 
+  out << endl;
+
+  out << indent() << "var telemetryData = TelemetryDictionary()" << endl;
+
+  for (const auto& member : tstruct->get_members()) {
+    bool optional = field_is_optional(member);
+    if (optional) {
+      out << indent() << "if let " << struct_property_name(member) << " = " << struct_property_name(member);
+      block_open(out);
+    }
+
+    out << indent() << "telemetryData[\"" << member->get_name() << "\"] = ";
+    if (member->get_type()->is_enum()) {
+      out << struct_property_name(member) << ".telemetryValue()";
+    }
+    else {
+      out << "TelemetryValue(" << struct_property_name(member) << ")";
+    }
+    out << endl;
+
+    if (optional) {
+      block_close(out);
+    }
+  }
+
+  out << indent() << "return telemetryData" << endl;
+  
+  block_close(out);
+  block_close(out);
+
+  out << endl;
 }
 
 /**
@@ -739,24 +810,18 @@ void t_swift_generator::generate_swift_struct_thrift_extension(ofstream& out,
                                                                bool is_result,
                                                                bool is_private) {
 
-  indent(out) << "extension " << tstruct->get_name();
-  if (!exclude_thrift_types_) {
-    out << " : TStruct";
-  }
-
+  indent(out) << "extension " << tstruct->get_name() << " : TStruct";
   block_open(out);
 
   out << endl;
 
-  if (!exclude_thrift_types_) {
-    generate_swift_struct_reader(out, tstruct, is_private);
+  generate_swift_struct_reader(out, tstruct, is_private);
 
-    if (is_result) {
-      generate_swift_struct_result_writer(out, tstruct);
-    }
-    else {
-      generate_swift_struct_writer(out, tstruct, is_private);
-    }
+  if (is_result) {
+    generate_swift_struct_result_writer(out, tstruct);
+  }
+  else {
+    generate_swift_struct_writer(out, tstruct, is_private);
   }
 
   block_close(out);
@@ -792,7 +857,7 @@ void t_swift_generator::generate_swift_struct_reader(ofstream& out,
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     bool optional = field_is_optional(*f_iter);
-    indent(out) << "var " << maybe_escape_identifier((*f_iter)->get_name()) << " : "
+    indent(out) << "var " << maybe_escape_identifier(struct_property_name(*f_iter)) << " : "
                 << type_name((*f_iter)->get_type(), optional, !optional) << endl;
   }
 
@@ -908,8 +973,8 @@ void t_swift_generator::generate_swift_struct_writer(ofstream& out,
 
     bool optional = field_is_optional(tfield);
     if (optional) {
-      indent(out) << "if let " << maybe_escape_identifier(tfield->get_name())
-                  << " = __value." << maybe_escape_identifier(tfield->get_name());
+      indent(out) << "if let " << maybe_escape_identifier(struct_property_name(tfield))
+                  << " = __value." << maybe_escape_identifier(struct_property_name(tfield));
       block_open(out);
     }
 
@@ -963,7 +1028,7 @@ void t_swift_generator::generate_swift_struct_result_writer(ofstream& out, t_str
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     t_field *tfield = *f_iter;
 
-    indent(out) << "if let result = __value." << (*f_iter)->get_name();
+    indent(out) << "if let result = __value." << struct_property_name(*f_iter);
 
     block_open(out);
 
@@ -1011,7 +1076,7 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
     indent(out) << "desc += \"" << (*f_iter)->get_name()
-                << "=\\(self." << maybe_escape_identifier((*f_iter)->get_name()) << ")";
+                << "=\\(self." << maybe_escape_identifier(struct_property_name(*f_iter)) << ")";
     if (++f_iter != fields.end()) {
       out << ", ";
     }
@@ -1352,7 +1417,7 @@ void t_swift_generator::generate_swift_service_client_send_function_implementati
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
     t_field *tfield = (*f_iter);
-    out << tfield->get_name() << ": " << tfield->get_name();
+    out << struct_property_name(tfield) << ": " << struct_property_name(tfield);
     if (++f_iter != fields.end()) {
       out << ", ";
     }
@@ -1425,9 +1490,9 @@ void t_swift_generator::generate_swift_service_client_recv_function_implementati
   vector<t_field*>::const_iterator x_iter;
 
   for (x_iter = xceptions.begin(); x_iter != xceptions.end(); ++x_iter) {
-    indent(out) << "if let " << (*x_iter)->get_name() << " = __result." << (*x_iter)->get_name();
+    indent(out) << "if let " << struct_property_name(*x_iter) << " = __result." << struct_property_name(*x_iter);
     block_open(out);
-    indent(out) << "throw " << (*x_iter)->get_name() << endl;
+    indent(out) << "throw " << struct_property_name(*x_iter) << endl;
     block_close(out);
   }
 
@@ -1464,7 +1529,7 @@ void t_swift_generator::generate_swift_service_client_send_function_invocation(o
   vector<t_field*>::const_iterator f_iter;
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
-    out << (*f_iter)->get_name() << ": " << (*f_iter)->get_name();
+    out << (*f_iter)->get_name() << ": " << struct_property_name(*f_iter);
     if (++f_iter != fields.end()) {
       out << ", ";
     }
@@ -1489,7 +1554,7 @@ void t_swift_generator::generate_swift_service_client_send_async_function_invoca
   indent(out) << "try send_" << tfunction->get_name() << "(__protocol";
 
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    out << ", " << (*f_iter)->get_name() << ": " << (*f_iter)->get_name();
+    out << ", " << struct_property_name(*f_iter) << ": " << struct_property_name(*f_iter);
   }
 
   out << ")" << endl;
@@ -1758,7 +1823,7 @@ void t_swift_generator::generate_swift_service_server_implementation(ofstream& o
       vector<t_field*>::const_iterator f_iter;
 
       for (f_iter = fields.begin(); f_iter != fields.end();) {
-        string fieldName = (*f_iter)->get_name();
+        string fieldName = struct_property_name(*f_iter);
         if (f_iter != fields.begin()) {
           out << fieldName << ": ";
         }
@@ -1779,7 +1844,7 @@ void t_swift_generator::generate_swift_service_server_implementation(ofstream& o
       for (x_iter = xfields.begin(); x_iter != xfields.end(); ++x_iter) {
         indent(out) << "catch let error as " << (*x_iter)->get_type()->get_name();
         block_open(out);
-        indent(out) << "result." << (*x_iter)->get_name() << " = error" << endl;
+        indent(out) << "result." << struct_property_name(*x_iter) << " = error" << endl;
         block_close(out);
       }
 
@@ -1974,7 +2039,7 @@ void t_swift_generator::render_const_value(ostream& out,
       t_field* tfield = *f_iter;
       t_const_value* value = NULL;
       for (v_iter = val.begin(); v_iter != val.end(); ++v_iter) {
-        if (tfield->get_name() == v_iter->first->get_string()) {
+        if (struct_property_name(tfield) == v_iter->first->get_string()) {
           value = v_iter->second;
         }
       }
@@ -2074,7 +2139,7 @@ string t_swift_generator::declare_property(t_field* tfield, bool is_private) {
 
   ostringstream render;
 
-  render << visibility << " var " << maybe_escape_identifier(tfield->get_name());
+  render << visibility << " var " << maybe_escape_identifier(struct_property_name(tfield));
 
   if (field_is_optional(tfield)) {
     render << " : " << type_name(tfield->get_type(), true);
@@ -2173,7 +2238,7 @@ string t_swift_generator::argument_list(t_struct* tstruct, string protocol_name,
 
   for (f_iter = fields.begin(); f_iter != fields.end();) {
     t_field* arg = *f_iter;
-    result += arg->get_name() + ": " + type_name(arg->get_type());
+    result += struct_property_name(arg) + ": " + type_name(arg->get_type());
 
     if (++f_iter != fields.end()) {
       result += ", ";
@@ -2213,6 +2278,11 @@ void t_swift_generator::populate_reserved_words() {
   swift_reserved_words_.insert("true");
   swift_reserved_words_.insert("typealias");
   swift_reserved_words_.insert("where");
+}
+
+string t_swift_generator::struct_property_name(t_field* tfield) {
+  // TODO: Camel-case
+  return tfield->get_name();
 }
 
 string t_swift_generator::enum_value_name(t_enum_value* tenumvalue) {


### PR DESCRIPTION
Add the following args:

- `exclude_thrift_types` - This changes the code so we only use Foundation types in the Swift generated code, not `Thrift` types
- `telemetry_object` - This adds the `TelemetryObject` protocol and `TelemetryValue` enum which makes it easier to send strongly typed telemetry.

This PR also changes the property names and enum cases to be camel-cased instead of underscored.

There are also various fixes to support later versions of Swift (using `hash(into:)` instead of `hashValue` and using `String(describing:)` to print well-formed descriptions).