### PR TITLE
Update Swift Equatable implementation

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -698,7 +698,13 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
 
   string visibility = is_private ? "private" : "public";
 
-  indent(out) << visibility << " func ==(lhs: " << type_name(tstruct) << ", rhs: " << type_name(tstruct) << ") -> Bool";
+  indent(out) << "extension " << tstruct->get_name() << " : Equatable";
+
+  block_open(out);
+
+  out << endl;
+
+  indent(out) << visibility << " static func ==(lhs: " << type_name(tstruct) << ", rhs: " << type_name(tstruct) << ") -> Bool";
 
   block_open(out);
 
@@ -729,6 +735,10 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
   else {
     out << " true" << endl;
   }
+
+  block_close(out);
+
+  out << endl;
 
   block_close(out);
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -698,7 +698,7 @@ void t_swift_generator::generate_swift_struct_equatable_extension(ofstream& out,
 
   string visibility = is_private ? "private" : "public";
 
-  indent(out) << "extension " << tstruct->get_name() << " : Equatable";
+  indent(out) << "extension " << type_name(tstruct) << " : Equatable";
 
   block_open(out);
 


### PR DESCRIPTION
I'm hoping this will decrease compilation time. If so, I'll close [this PR](https://github.com/outlook/thrift/pull/13) that adds an arg to remove the Equatable implementation.

Update Swift Equatable implementation to be an extension on the class rather than a free function.