### PR TITLE
Add option to generate separate Swift files

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -67,6 +67,7 @@ public:
     exclude_empty_init_ = false;
     exclude_equatable_ = false;
     exclude_printable_ = false;
+    separate_files_ = false;
 
     for( iter = parsed_options.begin(); iter != parsed_options.end(); ++iter) {
       if( iter->first.compare("log_unexpected") == 0) {
@@ -87,6 +88,8 @@ public:
         exclude_equatable_ = true;
       } else if( iter->first.compare("exclude_printable") == 0) {
         exclude_printable_ = true;
+      } else if( iter->first.compare("separate_files") == 0) {
+        separate_files_ = true;
       }
       else {
         throw "unknown option swift:" + iter->first;
@@ -189,6 +192,8 @@ public:
   void generate_swift_service_server_implementation(ofstream& out, t_service* tservice);
   void generate_swift_service_helpers(t_service* tservice);
 
+  void create_file(ofstream& out, string file_name);
+
   /**
    * Helper rendering functions
    */
@@ -260,6 +265,9 @@ private:
   ofstream f_decl_;
   ofstream f_impl_;
 
+  string f_decl_name_;
+  string f_impl_name_;
+
   bool log_unexpected_;
   bool async_clients_;
   bool promise_kit_;
@@ -269,6 +277,7 @@ private:
   bool exclude_empty_init_;
   bool exclude_equatable_;
   bool exclude_printable_;
+  bool separate_files_;
 
   set<string> swift_reserved_words_;
 };
@@ -283,23 +292,13 @@ void t_swift_generator::init_generator() {
 
   populate_reserved_words();
 
-  // we have a .swift declarations file...
-  string f_decl_name = capitalize(program_name_) + ".swift";
-  string f_decl_fullname = get_out_dir() + f_decl_name;
-  f_decl_.open(f_decl_fullname.c_str());
+  // we have a declarations file...
+  f_decl_name_ = get_out_dir() + capitalize(program_name_) + ".swift";
+  create_file(f_decl_, capitalize(program_name_));
 
-  f_decl_ << autogen_comment() << endl;
-
-  f_decl_ << swift_imports() << swift_thrift_imports() << endl;
-
-  // ...and a .swift implementation extensions file
-  string f_impl_name = capitalize(program_name_) + "+Exts.swift";
-  string f_impl_fullname = get_out_dir() + f_impl_name;
-  f_impl_.open(f_impl_fullname.c_str());
-
-  f_impl_ << autogen_comment() << endl;
-
-  f_impl_ << swift_imports() << swift_thrift_imports() << endl;
+  // ...and a implementation extensions file
+  f_impl_name_ = get_out_dir() + capitalize(program_name_) + "+Exts.swift";
+  create_file(f_impl_, capitalize(program_name_) + "+Exts");
 
   if (telemetry_object_) {
     f_impl_ << telemetry_object_protocols() << endl << endl;
@@ -428,70 +427,82 @@ void t_swift_generator::generate_typedef(t_typedef* ttypedef) {
  * @param tenum The enumeration
  */
 void t_swift_generator::generate_enum(t_enum* tenum) {
-  print_doc(f_decl_, tenum, false);
+  ofstream f_enum;
+  if (separate_files_) {
+    create_file(f_enum, tenum->get_name());
+  }
+  else {
+    f_enum.open(f_decl_name_);
+  }
 
-  f_decl_ << indent() << "public enum " << tenum->get_name() << " : Int32";
-  block_open(f_decl_);
+  print_doc(f_enum, tenum, false);
+
+  f_enum << indent() << "public enum " << tenum->get_name() << " : Int32";
+  block_open(f_enum);
 
   vector<t_enum_value*> constants = tenum->get_constants();
   vector<t_enum_value*>::iterator c_iter;
 
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-    print_doc(f_decl_, *c_iter, true);
-    f_decl_ << indent() << "case " << enum_value_name(*c_iter)
-            << " = " << (*c_iter)->get_value() << endl;
+    print_doc(f_enum, *c_iter, true);
+    f_enum << indent() << "case " << enum_value_name(*c_iter)
+           << " = " << (*c_iter)->get_value() << endl;
   }
 
   if (!exclude_empty_init_) {
-    f_decl_ << endl;
-    f_decl_ << indent() << "public init() { self.init(rawValue: " << constants.front()->get_value() << ")! }" << endl;
+    f_enum << endl;
+    f_enum << indent() << "public init() { self.init(rawValue: " << constants.front()->get_value() << ")! }" << endl;
   }
 
-  block_close(f_decl_);
-  f_decl_ << endl;
+  block_close(f_enum);
+  f_enum << endl;
 
-  f_impl_ << indent() << "extension " << tenum->get_name();
-  if (!exclude_thrift_types_) {
-    f_impl_ << " : TEnum";
+  if (!separate_files_) {
+    f_enum.open(f_impl_name_);
   }
-  block_open(f_impl_);
 
-  f_impl_ << endl;
+  f_enum << indent() << "extension " << tenum->get_name();
+  if (!exclude_thrift_types_) {
+    f_enum << " : TEnum";
+  }
+  block_open(f_enum);
+
+  f_enum << endl;
 
   if (!exclude_thrift_types_) {
-    f_impl_ << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
-    block_open(f_impl_);
-    f_impl_ << indent() << "var raw = Int32()" << endl
-            << indent() << "try proto.readI32(&raw)" << endl
-            << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
-    block_close(f_impl_);
-    f_impl_ << endl;
+    f_enum << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
+    block_open(f_enum);
+    f_enum << indent() << "var raw = Int32()" << endl
+           << indent() << "try proto.readI32(&raw)" << endl
+           << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
+    block_close(f_enum);
+    f_enum << endl;
 
-    f_impl_ << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
-    block_open(f_impl_);
-    f_impl_ << indent() << "try proto.writeI32(value.rawValue)" << endl;
-    block_close(f_impl_);
-    f_impl_ << endl;
+    f_enum << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
+    block_open(f_enum);
+    f_enum << indent() << "try proto.writeI32(value.rawValue)" << endl;
+    block_close(f_enum);
+    f_enum << endl;
   }
 
   if (telemetry_object_) {
-    f_impl_ << indent() << "public func telemetryName() -> String";
-    block_open(f_impl_);
+    f_enum << indent() << "public func telemetryName() -> String";
+    block_open(f_enum);
     if (boost::algorithm::ends_with(tenum->get_name(), "AsInt")) {
-      f_impl_ << indent() << "return \"\\(rawValue)\"" << endl;
+      f_enum << indent() << "return \"\\(rawValue)\"" << endl;
     }
     else {
-      f_impl_ << indent() << "switch self {" << endl;
+      f_enum << indent() << "switch self {" << endl;
       for (const auto& value : tenum->get_constants()) {
-        f_impl_ << indent() << "case ." << enum_value_name(value) << ": return \"" << value->get_name() << "\"" << endl;
+        f_enum << indent() << "case ." << enum_value_name(value) << ": return \"" << value->get_name() << "\"" << endl;
       }
-      f_impl_ << indent() << "}" << endl;
+      f_enum << indent() << "}" << endl;
     }
-    block_close(f_impl_);
+    block_close(f_enum);
   }
 
-  block_close(f_impl_);
-  f_impl_ << endl;
+  block_close(f_enum);
+  f_enum << endl;
 }
 
 /**
@@ -2582,6 +2593,18 @@ string t_swift_generator::type_to_enum(t_type* type, bool qualified) {
   throw "INVALID TYPE IN type_to_enum: " + type->get_name();
 }
 
+/**
+ * Creates a file in the output directory with the given name.
+ */
+void t_swift_generator::create_file(ofstream& out, string file_name) {
+  string file_stream_fullname = get_out_dir() + file_name + ".swift";
+  out.open(file_stream_fullname.c_str());
+
+  out << autogen_comment() << endl;
+
+  out << swift_imports() << swift_thrift_imports() << endl;
+}
+
 
 THRIFT_REGISTER_GENERATOR(
     swift,
@@ -2600,4 +2623,5 @@ THRIFT_REGISTER_GENERATOR(
     "    exclude_equatable:\n"
     "                     Do not generate Equatable and Hashable implementations\n"
     "    exclude_printable:\n"
-    "                     Do not generate CustomStringConvertible implementation\n")
+    "                     Do not generate CustomStringConvertible implementation\n"
+    "    separate_files:  Create a separate file for each type\n")

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -114,9 +114,13 @@ public:
 
   void generate_typedef(t_typedef* ttypedef);
   void generate_enum(t_enum* tenum);
+  void generate_enum(ofstream& f_enum_decl, ofstream& f_enum_impl, t_enum* tenum);
   void generate_struct(t_struct* tstruct);
+  void generate_struct(ofstream& f_struct_decl, ofstream& f_struct_impl, t_struct* tstruct);
   void generate_xception(t_struct* txception);
+  void generate_xception(ofstream& f_xception_decl, ofstream& f_xception_impl, t_struct* txception);
   void generate_service(t_service* tservice);
+  void generate_service(ofstream& f_service_impl, t_service* tservice);
 
   void print_const_value(ostream& out,
                          string name,
@@ -162,7 +166,7 @@ public:
 
   string function_result_helper_struct_type(t_service *tservice, t_function* tfunction);
   string function_args_helper_struct_type(t_service* tservice, t_function* tfunction);
-  void generate_function_helpers(t_service *tservice, t_function* tfunction);
+  void generate_function_helpers(ofstream& f_service_impl, t_service *tservice, t_function* tfunction);
 
   /**
    * Service-level generation functions
@@ -190,7 +194,7 @@ public:
 
   void generate_swift_service_server(ofstream& out, t_service* tservice);
   void generate_swift_service_server_implementation(ofstream& out, t_service* tservice);
-  void generate_swift_service_helpers(t_service* tservice);
+  void generate_swift_service_helpers(ofstream& f_service_impl, t_service* tservice);
 
   void create_file(ofstream& out, string file_name);
 
@@ -427,82 +431,82 @@ void t_swift_generator::generate_typedef(t_typedef* ttypedef) {
  * @param tenum The enumeration
  */
 void t_swift_generator::generate_enum(t_enum* tenum) {
-  ofstream f_enum;
   if (separate_files_) {
+    ofstream f_enum;
     create_file(f_enum, tenum->get_name());
+
+    generate_enum(f_enum, f_enum, tenum);
   }
   else {
-    f_enum.open(f_decl_name_);
+    generate_enum(f_decl_, f_impl_, tenum);
   }
+}
 
-  print_doc(f_enum, tenum, false);
+void t_swift_generator::generate_enum(ofstream& f_enum_decl, ofstream& f_enum_impl, t_enum* tenum) {
+  print_doc(f_enum_decl, tenum, false);
 
-  f_enum << indent() << "public enum " << tenum->get_name() << " : Int32";
-  block_open(f_enum);
+  f_enum_decl << indent() << "public enum " << tenum->get_name() << " : Int32";
+  block_open(f_enum_decl);
 
   vector<t_enum_value*> constants = tenum->get_constants();
   vector<t_enum_value*>::iterator c_iter;
 
   for (c_iter = constants.begin(); c_iter != constants.end(); ++c_iter) {
-    print_doc(f_enum, *c_iter, true);
-    f_enum << indent() << "case " << enum_value_name(*c_iter)
-           << " = " << (*c_iter)->get_value() << endl;
+    print_doc(f_enum_decl, *c_iter, true);
+    f_enum_decl << indent() << "case " << enum_value_name(*c_iter)
+                << " = " << (*c_iter)->get_value() << endl;
   }
 
   if (!exclude_empty_init_) {
-    f_enum << endl;
-    f_enum << indent() << "public init() { self.init(rawValue: " << constants.front()->get_value() << ")! }" << endl;
+    f_enum_decl << endl;
+    f_enum_decl << indent() << "public init() { self.init(rawValue: " << constants.front()->get_value() << ")! }" << endl;
   }
 
-  block_close(f_enum);
-  f_enum << endl;
+  block_close(f_enum_decl);
+  f_enum_decl << endl;
 
-  if (!separate_files_) {
-    f_enum.open(f_impl_name_);
-  }
-
-  f_enum << indent() << "extension " << tenum->get_name();
+  f_enum_impl << indent() << "extension " << tenum->get_name();
   if (!exclude_thrift_types_) {
-    f_enum << " : TEnum";
+    f_enum_impl << " : TEnum";
   }
-  block_open(f_enum);
+  block_open(f_enum_impl);
 
-  f_enum << endl;
+  f_enum_impl << endl;
 
   if (!exclude_thrift_types_) {
-    f_enum << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
-    block_open(f_enum);
-    f_enum << indent() << "var raw = Int32()" << endl
-           << indent() << "try proto.readI32(&raw)" << endl
-           << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
-    block_close(f_enum);
-    f_enum << endl;
+    f_enum_impl << indent() << "public static func readValueFromProtocol(proto: TProtocol) throws -> " << tenum->get_name();
+    block_open(f_enum_impl);
+    f_enum_impl << indent() << "var raw = Int32()" << endl
+                << indent() << "try proto.readI32(&raw)" << endl
+                << indent() << "return " << tenum->get_name() << "(rawValue: raw)!" << endl;
+    block_close(f_enum_impl);
+    f_enum_impl << endl;
 
-    f_enum << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
-    block_open(f_enum);
-    f_enum << indent() << "try proto.writeI32(value.rawValue)" << endl;
-    block_close(f_enum);
-    f_enum << endl;
+    f_enum_impl << indent() << "public static func writeValue(value: " << tenum->get_name() << ", toProtocol proto: TProtocol) throws";
+    block_open(f_enum_impl);
+    f_enum_impl << indent() << "try proto.writeI32(value.rawValue)" << endl;
+    block_close(f_enum_impl);
+    f_enum_impl << endl;
   }
 
   if (telemetry_object_) {
-    f_enum << indent() << "public func telemetryName() -> String";
-    block_open(f_enum);
+    f_enum_impl << indent() << "public func telemetryName() -> String";
+    block_open(f_enum_impl);
     if (boost::algorithm::ends_with(tenum->get_name(), "AsInt")) {
-      f_enum << indent() << "return \"\\(rawValue)\"" << endl;
+      f_enum_impl << indent() << "return \"\\(rawValue)\"" << endl;
     }
     else {
-      f_enum << indent() << "switch self {" << endl;
+      f_enum_impl << indent() << "switch self {" << endl;
       for (const auto& value : tenum->get_constants()) {
-        f_enum << indent() << "case ." << enum_value_name(value) << ": return \"" << value->get_name() << "\"" << endl;
+        f_enum_impl << indent() << "case ." << enum_value_name(value) << ": return \"" << value->get_name() << "\"" << endl;
       }
-      f_enum << indent() << "}" << endl;
+      f_enum_impl << indent() << "}" << endl;
     }
-    block_close(f_enum);
+    block_close(f_enum_impl);
   }
 
-  block_close(f_enum);
-  f_enum << endl;
+  block_close(f_enum_impl);
+  f_enum_impl << endl;
 }
 
 /**
@@ -540,21 +544,20 @@ void t_swift_generator::generate_consts(vector<t_const*> consts) {
  * @param tstruct The struct definition
  */
 void t_swift_generator::generate_struct(t_struct* tstruct) {
-  ofstream f_struct;
   if (separate_files_) {
+    ofstream f_struct;
     create_file(f_struct, tstruct->get_name());
+
+    generate_struct(f_struct, f_struct, tstruct);
   }
   else {
-    f_struct.open(f_decl_name_);
+    generate_struct(f_decl_, f_impl_, tstruct);
   }
+}
 
-  generate_swift_struct(f_struct, tstruct, false);
-
-  if (!separate_files_) {
-    f_struct.open(f_impl_name_);
-  }
-
-  generate_swift_struct_implementation(f_struct, tstruct, false, false);
+void t_swift_generator::generate_struct(ofstream& f_struct_decl, ofstream& f_struct_impl, t_struct* tstruct) {
+  generate_swift_struct(f_struct_decl, tstruct, false);
+  generate_swift_struct_implementation(f_struct_impl, tstruct, false, false);
 }
 
 /**
@@ -563,21 +566,20 @@ void t_swift_generator::generate_struct(t_struct* tstruct) {
  * @param tstruct The struct definition
  */
 void t_swift_generator::generate_xception(t_struct* txception) {
-  ofstream f_xception;
   if (separate_files_) {
+    ofstream f_xception;
     create_file(f_xception, txception->get_name());
+
+    generate_xception(f_xception, f_xception, txception);
   }
   else {
-    f_xception.open(f_decl_name_);
+    generate_xception(f_decl_, f_impl_, txception);
   }
+}
 
-  generate_swift_struct(f_xception, txception, false);
-
-  if (!separate_files_) {
-    f_xception.open(f_impl_name_);
-  }
-
-  generate_swift_struct_implementation(f_xception, txception, false, false);
+void t_swift_generator::generate_xception(ofstream& f_xception_decl, ofstream& f_xception_impl, t_struct* txception) {
+  generate_swift_struct(f_xception_decl, txception, false);
+  generate_swift_struct_implementation(f_xception_impl, txception, false, false);
 }
 
 /**
@@ -1258,14 +1260,18 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
  * @param tservice The service definition
  */
 void t_swift_generator::generate_service(t_service* tservice) {
-  ofstream f_xception;
   if (separate_files_) {
-    create_file(f_xception, tservice->get_name());
+    ofstream f_service;
+    create_file(f_service, tservice->get_name());
+
+    generate_service(f_service, tservice);
   }
   else {
-    f_xception.open(f_impl_name_);
+    generate_service(f_impl_, tservice);
   }
+}
 
+void t_swift_generator::generate_service(ofstream& f_service_impl, t_service* tservice) {
   generate_swift_service_protocol(f_decl_, tservice);
   generate_swift_service_client(f_decl_, tservice);
   if (async_clients_) {
@@ -1274,13 +1280,13 @@ void t_swift_generator::generate_service(t_service* tservice) {
   }
   generate_swift_service_server(f_decl_, tservice);
 
-  generate_swift_service_helpers(tservice);
+  generate_swift_service_helpers(f_service_impl, tservice);
 
-  generate_swift_service_client_implementation(f_xception, tservice);
+  generate_swift_service_client_implementation(f_service_impl, tservice);
   if (async_clients_) {
-    generate_swift_service_client_async_implementation(f_xception, tservice);
+    generate_swift_service_client_async_implementation(f_service_impl, tservice);
   }
-  generate_swift_service_server_implementation(f_xception, tservice);
+  generate_swift_service_server_implementation(f_service_impl, tservice);
 }
 
 /**
@@ -1288,15 +1294,7 @@ void t_swift_generator::generate_service(t_service* tservice) {
  *
  * @param tservice The service
  */
-void t_swift_generator::generate_swift_service_helpers(t_service* tservice) {
-  ofstream f_service;
-  if (separate_files_) {
-    create_file(f_service, tservice->get_name());
-  }
-  else {
-    f_service.open(f_impl_name_);
-  }
-
+void t_swift_generator::generate_swift_service_helpers(ofstream& f_service_impl, t_service* tservice) {
   vector<t_function*> functions = tservice->get_functions();
   vector<t_function*>::iterator f_iter;
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
@@ -1313,9 +1311,9 @@ void t_swift_generator::generate_swift_service_helpers(t_service* tservice) {
       qname_ts.append(*m_iter);
     }
 
-    generate_swift_struct(f_service, &qname_ts, true);
-    generate_swift_struct_implementation(f_service, &qname_ts, false, true);
-    generate_function_helpers(tservice, *f_iter);
+    generate_swift_struct(f_service_impl, &qname_ts, true);
+    generate_swift_struct_implementation(f_service_impl, &qname_ts, false, true);
+    generate_function_helpers(f_service_impl, tservice, *f_iter);
   }
 }
 
@@ -1336,17 +1334,9 @@ string t_swift_generator::function_args_helper_struct_type(t_service *tservice, 
  *
  * @param tfunction The function
  */
-void t_swift_generator::generate_function_helpers(t_service *tservice, t_function* tfunction) {
+void t_swift_generator::generate_function_helpers(ofstream& f_service_impl, t_service *tservice, t_function* tfunction) {
   if (tfunction->is_oneway()) {
     return;
-  }
-
-  ofstream f_service;
-  if (separate_files_) {
-    create_file(f_service, tservice->get_name());
-  }
-  else {
-    f_service.open(f_impl_name_);
   }
 
   // create a result struct with a success field of the return type,
@@ -1369,8 +1359,8 @@ void t_swift_generator::generate_function_helpers(t_service *tservice, t_functio
   }
 
   // generate the result struct
-  generate_swift_struct(f_service, &result, true);
-  generate_swift_struct_implementation(f_service, &result, true, true);
+  generate_swift_struct(f_service_impl, &result, true);
+  generate_swift_struct_implementation(f_service_impl, &result, true, true);
 
   for (f_iter = result.get_members().begin(); f_iter != result.get_members().end(); ++f_iter) {
     delete *f_iter;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -540,8 +540,21 @@ void t_swift_generator::generate_consts(vector<t_const*> consts) {
  * @param tstruct The struct definition
  */
 void t_swift_generator::generate_struct(t_struct* tstruct) {
-  generate_swift_struct(f_decl_, tstruct, false);
-  generate_swift_struct_implementation(f_impl_, tstruct, false, false);
+  ofstream f_struct;
+  if (separate_files_) {
+    create_file(f_struct, tstruct->get_name());
+  }
+  else {
+    f_struct.open(f_decl_name_);
+  }
+
+  generate_swift_struct(f_struct, tstruct, false);
+
+  if (!separate_files_) {
+    f_struct.open(f_impl_name_);
+  }
+
+  generate_swift_struct_implementation(f_struct, tstruct, false, false);
 }
 
 /**

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -563,8 +563,21 @@ void t_swift_generator::generate_struct(t_struct* tstruct) {
  * @param tstruct The struct definition
  */
 void t_swift_generator::generate_xception(t_struct* txception) {
-  generate_swift_struct(f_decl_, txception, false);
-  generate_swift_struct_implementation(f_impl_, txception, false, false);
+  ofstream f_xception;
+  if (separate_files_) {
+    create_file(f_xception, txception->get_name());
+  }
+  else {
+    f_xception.open(f_decl_name_);
+  }
+
+  generate_swift_struct(f_xception, txception, false);
+
+  if (!separate_files_) {
+    f_xception.open(f_impl_name_);
+  }
+
+  generate_swift_struct_implementation(f_xception, txception, false, false);
 }
 
 /**
@@ -1245,6 +1258,13 @@ void t_swift_generator::generate_swift_struct_printable_extension(ofstream& out,
  * @param tservice The service definition
  */
 void t_swift_generator::generate_service(t_service* tservice) {
+  ofstream f_xception;
+  if (separate_files_) {
+    create_file(f_xception, tservice->get_name());
+  }
+  else {
+    f_xception.open(f_impl_name_);
+  }
 
   generate_swift_service_protocol(f_decl_, tservice);
   generate_swift_service_client(f_decl_, tservice);
@@ -1256,11 +1276,11 @@ void t_swift_generator::generate_service(t_service* tservice) {
 
   generate_swift_service_helpers(tservice);
 
-  generate_swift_service_client_implementation(f_impl_, tservice);
+  generate_swift_service_client_implementation(f_xception, tservice);
   if (async_clients_) {
-    generate_swift_service_client_async_implementation(f_impl_, tservice);
+    generate_swift_service_client_async_implementation(f_xception, tservice);
   }
-  generate_swift_service_server_implementation(f_impl_, tservice);
+  generate_swift_service_server_implementation(f_xception, tservice);
 }
 
 /**
@@ -1269,6 +1289,14 @@ void t_swift_generator::generate_service(t_service* tservice) {
  * @param tservice The service
  */
 void t_swift_generator::generate_swift_service_helpers(t_service* tservice) {
+  ofstream f_service;
+  if (separate_files_) {
+    create_file(f_service, tservice->get_name());
+  }
+  else {
+    f_service.open(f_impl_name_);
+  }
+
   vector<t_function*> functions = tservice->get_functions();
   vector<t_function*>::iterator f_iter;
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
@@ -1285,8 +1313,8 @@ void t_swift_generator::generate_swift_service_helpers(t_service* tservice) {
       qname_ts.append(*m_iter);
     }
 
-    generate_swift_struct(f_impl_, &qname_ts, true);
-    generate_swift_struct_implementation(f_impl_, &qname_ts, false, true);
+    generate_swift_struct(f_service, &qname_ts, true);
+    generate_swift_struct_implementation(f_service, &qname_ts, false, true);
     generate_function_helpers(tservice, *f_iter);
   }
 }
@@ -1313,6 +1341,14 @@ void t_swift_generator::generate_function_helpers(t_service *tservice, t_functio
     return;
   }
 
+  ofstream f_service;
+  if (separate_files_) {
+    create_file(f_service, tservice->get_name());
+  }
+  else {
+    f_service.open(f_impl_name_);
+  }
+
   // create a result struct with a success field of the return type,
   // and a field for each type of exception thrown
   t_struct result(program_, function_result_helper_struct_type(tservice, tfunction));
@@ -1333,8 +1369,8 @@ void t_swift_generator::generate_function_helpers(t_service *tservice, t_functio
   }
 
   // generate the result struct
-  generate_swift_struct(f_impl_, &result, true);
-  generate_swift_struct_implementation(f_impl_, &result, true, true);
+  generate_swift_struct(f_service, &result, true);
+  generate_swift_struct_implementation(f_service, &result, true, true);
 
   for (f_iter = result.get_members().begin(); f_iter != result.get_members().end(); ++f_iter) {
     delete *f_iter;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -333,7 +333,7 @@ public enum TelemetryValue: Equatable {
   case bool(Bool)
   case dictionary(TelemetryDictionary)
 
-  fileprivate init(_ value: Any) {
+  init(_ value: Any) {
     if let string = value as? String {
       self = .string(string)
     }


### PR DESCRIPTION
Add an option to generate separate a Swift file per class/enum instead of all in one file.

We can't use this option yet because we need to figure out a way to add all the files in the folder to the Xcode project.