### PR TITLE
Adding support for swift sets + lists generation

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -131,6 +131,9 @@ public:
   void render_const_value(ostream& out,
                           t_type* type,
                           t_const_value* value);
+  void render_const_value_collection(ostream& out,
+                        t_type* etype,
+                        t_const_value* value);
   void print_doc(ostream& out, t_doc* tdoc, bool should_indent);
   void print_struct_init_doc(ostream& out, t_struct* tstruct, const vector<t_field*>& fields, bool all);
 
@@ -155,6 +158,7 @@ public:
   void generate_swift_struct_telemetry_object_extension(ofstream& out, t_struct* tstruct);
   void generate_swift_struct_telemetry_event_extension(ofstream& out, t_struct* tstruct);
   void telemetry_dictionary_value(ofstream& out, t_type* type, string property_name);
+  void telemetry_collection_value(ofstream& out, t_type* key_type, string property_name);
   void generate_swift_struct_thrift_extension(ofstream& out,
                                               t_struct* tstruct,
                                               bool is_result,
@@ -948,10 +952,55 @@ void t_swift_generator::telemetry_dictionary_value(ofstream& out, t_type* type, 
     out << ".string(" << property_name << ".telemetryName())";
   } else if (type->is_struct()) {
     out << "TelemetryValue(" << property_name << ")";
+  } else if (type->is_list()) {
+    t_list *tlist = (t_list*)type;
+    telemetry_collection_value(out, tlist->get_elem_type(), property_name);
+  } else if (type->is_set()) {
+    t_set *tset = (t_set*)type;
+    telemetry_collection_value(out, tset->get_elem_type(), property_name);
   }
   else {
     throw "compiler error: invalid type " + type->get_name();
   }
+}
+
+/**
+ * Helper to convert collection to a TelemetryObject that can be serializable
+ * when sending event as a telemetry dictionary
+ *
+ */
+void t_swift_generator::telemetry_collection_value(ofstream& out, t_type* key_type, string property_name) {
+  out << ".string({";
+
+  indent_up();
+  out << endl;
+
+  out << indent() << "var stringList: [String] = []" << endl;
+  out << indent() << "for item in " << property_name;
+
+  block_open(out);
+
+  out << indent() << "stringList.append(";
+
+  if (key_type->is_string()) {
+    out << "item";
+  } else if (key_type->is_enum()) {
+    out << "item.telemetryName()";
+  }
+  else {
+    throw "compiler error: unsupported key type for map " + key_type->get_name();
+  }
+
+  out << ");";
+
+  out << endl;
+
+  block_close(out);
+
+  out << indent() << "return stringList.joined(separator: \",\")" << endl;
+
+  block_close(out, false);
+  out << "())";
 }
 
 /**
@@ -2102,10 +2151,20 @@ string t_swift_generator::type_name(t_type* ttype, bool is_optional, bool is_for
     }
   } else if (ttype->is_set()) {
     t_set *set = (t_set *)ttype;
-    result = "TSet<" + type_name(set->get_elem_type()) + ">";
+    if (exclude_thrift_types_) {
+      result = "[" + type_name(set->get_elem_type()) + "]";
+    }
+    else {
+      result = "TSet<" + type_name(set->get_elem_type()) + ">";
+    }
   } else if (ttype->is_list()) {
     t_list *list = (t_list *)ttype;
-    result = "TList<" + type_name(list->get_elem_type()) + ">";
+    if (exclude_thrift_types_) {
+      result = "[" + type_name(list->get_elem_type()) + "]";
+    }
+    else {
+      result = "TList<" + type_name(list->get_elem_type()) + ">";
+    }
   }
   else {
     result = ttype->get_name();
@@ -2251,49 +2310,39 @@ void t_swift_generator::render_const_value(ostream& out,
     out << "]";
 
   } else if (type->is_list()) {
-
-    out << "[";
-
     t_type* etype = ((t_list*)type)->get_elem_type();
-
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
-
-    for (v_iter = val.begin(); v_iter != val.end();) {
-
-      render_const_value(out, etype, v_iter->first);
-
-      if (++v_iter != val.end()) {
-        out << ", ";
-      }
-    }
-
-    out << "]";
-
+    render_const_value_collection(out, etype, value);
   } else if (type->is_set()) {
-
-    out << "[";
-
     t_type* etype = ((t_set*)type)->get_elem_type();
-
-    const map<t_const_value*, t_const_value*>& val = value->get_map();
-    map<t_const_value*, t_const_value*>::const_iterator v_iter;
-
-    for (v_iter = val.begin(); v_iter != val.end();) {
-
-      render_const_value(out, etype, v_iter->first);
-
-      if (++v_iter != val.end()) {
-        out << ", ";
-      }
-    }
-
-    out << "]";
-
+    render_const_value_collection(out, etype, value);
   } else {
     throw "compiler error: no const of type " + type->get_name();
   }
 
+}
+
+/**
+ * Helper to render a collection of constants such as a set or list (as would be seen after an '=')
+ *
+ */
+void t_swift_generator::render_const_value_collection(ostream& out,
+                                             t_type* etype,
+                                             t_const_value* value) {
+  out << "[";
+
+  const vector<t_const_value*>& val = value->get_list();
+  vector<t_const_value*>::const_iterator v_iter;
+
+  for (v_iter = val.begin(); v_iter != val.end();) {
+
+    render_const_value(out, etype, *v_iter);
+
+    if (++v_iter != val.end()) {
+      out << ", ";
+    }
+  }
+
+  out << "]";
 }
 
 /**

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -866,11 +866,9 @@ void t_swift_generator::generate_swift_struct_telemetry_object_extension(ofstrea
 
   for (const auto& member : tstruct->get_members()) {
     bool optional = field_is_optional(member);
-    t_type* type = get_true_type(member->get_type());
 
-    // restricting set functionality to special cases, excluding from telemetry dictionary
-    if(type->is_set())
-    {
+    // types labeled as NonTelemetry will not be in the resulting telemetry dictionary
+    if (boost::algorithm::ends_with(type_name(member->get_type()), "NonTelemetry")) {
       continue;
     }
 
@@ -958,7 +956,7 @@ void t_swift_generator::telemetry_dictionary_value(ofstream& out, t_type* type, 
     out << "TelemetryValue(" << property_name << ")";
   } 
   else {
-    throw "compiler error: invalid type " + type->get_name();
+    throw "compiler error: invalid type (" + type->get_name() + ") for property \"" + property_name + "\"";
   }
 }
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -956,7 +956,7 @@ void t_swift_generator::telemetry_dictionary_value(ofstream& out, t_type* type, 
     out << "TelemetryValue(" << property_name << ")";
   } 
   else {
-    throw "compiler error: invalid type (" + type->get_name() + ") for property \"" + property_name + "\"";
+    throw "compiler error: invalid type (" + type_name(type) + ") for property \"" + property_name + "\"";
   }
 }
 


### PR DESCRIPTION
This change allows usage of a "set" and "list" types in thrift, that can now be converted into swift native types during generation. 

Thrift:
```
enum DayOfTheWeek {
  Monday,
  Tuesday,
  Wednesday,
  Thursday,
  Friday,
  Saturday,
  Sunday
}

struct Calendar {
  1: required list<DayOfTheWeek> WorkDays;
  2: required list<DayOfTheWeek> WeekendDays = [DayOfTheWeek.Saturday, DayOfTheWeek.Sunday];
}
```

gets converted into Swift:

```
public enum DayOfTheWeek : Int32 {
  case monday = 0
  case tuesday = 1
  case wednesday = 2
  case thursday = 3
  case friday = 4
  case saturday = 5
  case sunday = 6
}

public final class Calendar {

  public var workDays : [DayOfTheWeek]

  public var weekendDays = [DayOfTheWeek.saturday, DayOfTheWeek.sunday]

  public init(workDays: [DayOfTheWeek], weekendDays: [DayOfTheWeek]) {
    self.workDays = workDays
    self.weekendDays = weekendDays
  }
}
```

With this implementation, collections are converted to a comma delimited list when serialized into a TelemetryDictionary.

```
public func telemetryDictionary() -> TelemetryDictionary {

    var telemetryData = TelemetryDictionary()
    telemetryData["WorkDays"] = .string({
      var stringList: [String] = []
      for item in workDays {
        stringList.append(item.telemetryName());
      }
      return stringList.joined(separator: ",")
    }())
    telemetryData["WeekendDays"] = .string({
      var stringList: [String] = []
      for item in weekendDays {
        stringList.append(item.telemetryName());
      }
      return stringList.joined(separator: ",")
    }())
    return telemetryData
  }
```
 