### PR TITLE
Converting Array type to Set

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -2262,7 +2262,7 @@ void t_swift_generator::render_const_value(ostream& out,
     out << "]";
   } else if (type->is_set()) {
     t_type* etype = ((t_set*)type)->get_elem_type();
-    out << "Set<" << type_name(etype) << ">([";
+    out << "Set([";
 
     const vector<t_const_value*>& val = value->get_list();
     vector<t_const_value*>::const_iterator v_iter;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -2109,7 +2109,7 @@ string t_swift_generator::type_name(t_type* ttype, bool is_optional, bool is_for
   } else if (ttype->is_set()) {
     t_set *set = (t_set *)ttype;
     if (exclude_thrift_types_) {
-      result = "[" + type_name(set->get_elem_type()) + "]";
+      result = "Set<" + type_name(set->get_elem_type()) + ">";
     }
     else {
       result = "TSet<" + type_name(set->get_elem_type()) + ">";
@@ -2262,7 +2262,7 @@ void t_swift_generator::render_const_value(ostream& out,
     out << "]";
   } else if (type->is_set()) {
     t_type* etype = ((t_set*)type)->get_elem_type();
-    out << "[";
+    out << "Set<" << type_name(etype) << ">([";
 
     const vector<t_const_value*>& val = value->get_list();
     vector<t_const_value*>::const_iterator v_iter;
@@ -2276,7 +2276,7 @@ void t_swift_generator::render_const_value(ostream& out,
       }
     }
 
-    out << "]";
+    out << "])";
   } else {
     throw "compiler error: no const of type " + type->get_name();
   }


### PR DESCRIPTION
Previous change to enable generation of "set" thrift types in swift used Arrays instead of Sets in thrift. This change will make sure that a thrift set:

```
enum DayOfTheWeek {
  Monday,
  Tuesday,
  Wednesday,
  Thursday,
  Friday,
  Saturday,
  Sunday
}

typedef set<DayOfTheWeek> DaysOfTheWeekNonTelemetry;

struct Calendar {
  1: required DaysOfTheWeekNonTelemetry WorkDays;
  2: required DaysOfTheWeekNonTelemetry Weekend = [DayOfTheWeek.Saturday, DayOfTheWeek.Sunday];
 }
```

will generate 

```
public typealias DaysOfTheWeekNonTelemetry = Set<DayOfTheWeek>

public final class Calendar {

  public var workDays : DaysOfTheWeekNonTelemetry

  public var weekend = Set<DayOfTheWeek>([DayOfTheWeek.saturday, DayOfTheWeek.sunday])

  public init(workDays: DaysOfTheWeekNonTelemetry, weekend: DaysOfTheWeekNonTelemetry) {
    self.workDays = workDays
    self.weekend = weekend
  }

}
```