### PR TITLE
Do not keep the directory structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: chmod +x ./compiler/cpp/thrift
 
       - name: 'Zip files'
-        run: zip ./thrift.zip ./compiler/cpp/thrift
+        run: zip -j ./thrift.zip ./compiler/cpp/thrift
 
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
zip file will output as `./thrift` rather than `compiler/cpp/thrift`