### PR TITLE
Swift: Add Sendable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on: [push]
 jobs:
   Build:
-    runs-on: macos-latest
+    runs-on: macos-15-intel  # Uses x86_64 (Intel) runners - newer supported version
     steps:
       - uses: actions/checkout@v3
 
@@ -11,10 +11,11 @@ jobs:
 
       - name: Update environment variables
         run: |
-          echo "/opt/homebrew/opt/bison/bin" >> $GITHUB_PATH
-          export LDFLAGS="-L/opt/homebrew/opt/bison/lib"
-          export CFLAGS="-Wno-deprecated-copy-with-user-provided-copy"
-          export CXXFLAGS="-Wno-deprecated-copy-with-user-provided-copy"
+          echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+          export LDFLAGS="-L/usr/local/opt/bison/lib"
+          export CFLAGS="-Wno-deprecated-copy-with-user-provided-copy -arch x86_64"
+          export CXXFLAGS="-Wno-deprecated-copy-with-user-provided-copy -arch x86_64"
+          export LDFLAGS="$LDFLAGS -arch x86_64"
 
       - name: Boostrap
         run: ./bootstrap.sh

--- a/compiler/cpp/src/thrift/generate/t_erl_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_erl_generator.cc
@@ -385,7 +385,6 @@ void t_erl_generator::close_generator() {
 }
 
 void t_erl_generator::generate_type_metadata(std::string function_name, vector<string> names) {
-  vector<string>::iterator s_iter;
   size_t num_structs = names.size();
 
   indent(f_types_file_) << function_name << "() ->\n";
@@ -915,7 +914,6 @@ void t_erl_generator::generate_service(t_service* tservice) {
 void t_erl_generator::generate_service_metadata(t_service* tservice) {
   export_string("function_names", 0);
   vector<t_function*> functions = tservice->get_functions();
-  vector<t_function*>::iterator f_iter;
   size_t num_functions = functions.size();
 
   indent(f_service_) << "function_names() -> " << endl;

--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -2100,7 +2100,6 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
              << (*f_iter)->get_name() << "(";
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
-    vector<t_field*>::const_iterator a_iter;
     std::vector<t_field*>::size_type num_args = args.size();
     bool first = true;
 
@@ -2229,7 +2228,6 @@ void t_go_generator::generate_service_remote(t_service* tservice) {
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
-    vector<t_field*>::const_iterator a_iter;
     std::vector<t_field*>::size_type num_args = args.size();
     string funcName((*f_iter)->get_name());
     string pubName(publicize(funcName));
@@ -2614,7 +2612,6 @@ void t_go_generator::generate_process_function(t_service* tservice, t_function* 
 
   // t_struct* xs = tfunction->get_xceptions();
   // const std::vector<t_field*>& xceptions = xs->get_members();
-  vector<t_field*>::const_iterator x_iter;
   f_types_ << indent() << "type " << processorName << " struct {" << endl;
   f_types_ << indent() << "  handler " << publicize(tservice->get_name()) << endl;
   f_types_ << indent() << "}" << endl << endl;

--- a/compiler/cpp/src/thrift/generate/t_hs_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_hs_generator.cc
@@ -590,7 +590,6 @@ void t_hs_generator::generate_hs_struct_arbitrary(ofstream& out, t_struct* tstru
   string tname = type_name(tstruct);
   string name = tstruct->get_name();
   const vector<t_field*>& members = tstruct->get_members();
-  vector<t_field*>::const_iterator m_iter;
 
   indent(out) << "instance QC.Arbitrary " << tname << " where " << endl;
   indent_up();
@@ -654,7 +653,6 @@ void t_hs_generator::generate_hs_struct_arbitrary(ofstream& out, t_struct* tstru
  */
 void t_hs_generator::generate_hs_struct_reader(ofstream& out, t_struct* tstruct) {
   const vector<t_field*>& fields = tstruct->get_members();
-  vector<t_field*>::const_iterator f_iter;
 
   string sname = type_name(tstruct);
   string id = tmp("_id");
@@ -725,7 +723,6 @@ void t_hs_generator::generate_hs_struct_reader(ofstream& out, t_struct* tstruct)
 void t_hs_generator::generate_hs_struct_writer(ofstream& out, t_struct* tstruct) {
   string name = type_name(tstruct);
   const vector<t_field*>& fields = tstruct->get_sorted_members();
-  vector<t_field*>::const_iterator f_iter;
   string str = tmp("_str");
   string f = tmp("_f");
   string v = tmp("_v");
@@ -909,7 +906,6 @@ void t_hs_generator::generate_hs_function_helpers(t_function* tfunction) {
 void t_hs_generator::generate_hs_typemap(ofstream& out, t_struct* tstruct) {
   string name = type_name(tstruct);
   const vector<t_field*>& fields = tstruct->get_sorted_members();
-  vector<t_field*>::const_iterator f_iter;
 
   indent(out) << "typemap_" << name << " :: T.TypeMap" << endl;
   indent(out) << "typemap_" << name << " = Map.fromList [";

--- a/compiler/cpp/src/thrift/generate/t_py_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_py_generator.cc
@@ -1600,7 +1600,6 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
              << (*f_iter)->get_name() << "(";
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
-    vector<t_field*>::const_iterator a_iter;
     std::vector<t_field*>::size_type num_args = args.size();
     bool first = true;
     for (std::vector<t_field*>::size_type i = 0; i < num_args; ++i) {
@@ -1706,7 +1705,6 @@ void t_py_generator::generate_service_remote(t_service* tservice) {
 
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const std::vector<t_field*>& args = arg_struct->get_members();
-    vector<t_field*>::const_iterator a_iter;
     std::vector<t_field*>::size_type num_args = args.size();
 
     f_remote << "if cmd == '" << (*f_iter)->get_name() << "':" << endl;

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -330,7 +330,7 @@ string t_swift_generator::telemetry_object_protocols() {
   return R"objc(
 public typealias TelemetryDictionary = [String: TelemetryValue]
 
-public protocol TelemetryObject {
+public protocol TelemetryObject: Sendable {
   func telemetryDictionary() -> TelemetryDictionary
 }
 

--- a/compiler/cpp/src/thrift/generate/t_swift_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_swift_generator.cc
@@ -440,7 +440,7 @@ void t_swift_generator::generate_enum(t_enum* tenum) {
 void t_swift_generator::generate_enum(ofstream& f_enum_decl, ofstream& f_enum_impl, t_enum* tenum) {
   print_doc(f_enum_decl, tenum, false);
 
-  f_enum_decl << indent() << "public enum " << tenum->get_name() << " : Int32";
+  f_enum_decl << indent() << "public enum " << tenum->get_name() << " : Int, Sendable";
   block_open(f_enum_decl);
 
   vector<t_enum_value*> constants = tenum->get_constants();
@@ -596,7 +596,10 @@ void t_swift_generator::generate_swift_struct(ofstream& out,
   out << indent() << visibility << " " << object_type << " " << tstruct->get_name();
 
   if (tstruct->is_xception()) {
-    out << " : ErrorType";
+    out << " : ErrorType, @unchecked Sendable";
+  }
+  else {
+    out << " : @unchecked Sendable";
   }
 
   block_open(out);


### PR DESCRIPTION
Add Sendable conformance to generated Swift code. Classes conform to the unchecked Sendable protocol because they contain mutable properties.